### PR TITLE
connectionType alignment for RPC interfaces

### DIFF
--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -162,7 +162,7 @@ export class LavaSDK {
       const sendRelayOptions = {
         data: data,
         url: "",
-        connectionType: "GET", // temporary solution to spec changes - remove this when PRT-216 is fixed
+        connectionType: this.rpcInterface === "jsonrpc" ? "POST" : "",
       };
 
       // Send relay


### PR DESCRIPTION
SDK connection type alignment for PRT-216 (Fix param types)

Json RPC - Post
Tendermint - empty
gRPC - empty
REST - already valid ✅